### PR TITLE
lazily evaluate dynamic messages

### DIFF
--- a/src/lgtm/object_validator.js
+++ b/src/lgtm/object_validator.js
@@ -100,6 +100,10 @@ ObjectValidator.prototype = {
         let fn      = pair[0];
         let message = pair[1];
 
+        if(typeof message === 'function') {
+          message = message(value, attr, object);
+        }
+
         let promise = resolve()
           .then(() => fn(value, attr, object))
           .then(isValid => [ attr, isValid ? null : message ]);

--- a/src/lgtm/object_validator.js
+++ b/src/lgtm/object_validator.js
@@ -100,13 +100,17 @@ ObjectValidator.prototype = {
         let fn      = pair[0];
         let message = pair[1];
 
-        if(typeof message === 'function') {
-          message = message(value, attr, object);
-        }
-
         let promise = resolve()
           .then(() => fn(value, attr, object))
-          .then(isValid => [ attr, isValid ? null : message ]);
+          .then(function(isValid) {
+            if (isValid) {
+              message = null;
+            }
+            else if (typeof message === 'function') {
+              message = message(value, attr, object);
+            }
+            return [ attr, message ];
+          });
 
         results.push(promise);
       });

--- a/test/object_validator_test.js
+++ b/test/object_validator_test.js
@@ -142,6 +142,24 @@ describe('ObjectValidator', function() {
     );
   });
 
+  it('creates a dynamic message when given a function for validation message', () => {
+    validator.addValidation('text',
+    (text => text.length == 12),
+    (text => `Text should be 12 characters long. (${text.length}/12)`));
+
+    return validator.validate({text: '12345678901'}).then((result) => {
+      deepEqual(
+        result,
+        {
+          valid: false,
+          errors: {
+            text: [`Text should be 12 characters long. (11/12)`]
+          }
+        }
+      );
+    });
+  });
+
   context('with validations that return immediately', () => {
     beforeEach(() => {
       validator.addValidation('firstName',


### PR DESCRIPTION
This allows the dynamic message to be evaluated only on validation failure, and after the failure occurs. This allows the dynamic message function to better know why the failure has occurred (via access to closures, other objects, etc).